### PR TITLE
Changing the location of an included script to be local

### DIFF
--- a/Get-BrokenLinksInMdDocuments.ps1
+++ b/Get-BrokenLinksInMdDocuments.ps1
@@ -60,7 +60,7 @@ function Get-BrokenLinksInMdDocuments()
         -   Enable save statistics
     #>
 
-    . "C:\GIT\juanpablo.jofre@bitbucket.org\powershell\PowerShell-Docs\DocumentManagement\Get-Relativepath.ps1"
+    . "Get-Relativepath.ps1"
     $initialWarningPreference = $WarningPreference
     $initialErrorActionPreference = $ErrorActionPreference
 

--- a/Update-MetadataInTopics.ps1
+++ b/Update-MetadataInTopics.ps1
@@ -25,6 +25,7 @@ function Update-MetadataInTopics()
         [parameter(Mandatory=$false)] [hashtable] $NewMetadata
     )
 
+    . "Update-Metadata.ps1"
 
     if(-not $newMetadata){
         $newMetadata = @{

--- a/Update-MetadataInTopics.ps1
+++ b/Update-MetadataInTopics.ps1
@@ -25,7 +25,6 @@ function Update-MetadataInTopics()
         [parameter(Mandatory=$false)] [hashtable] $NewMetadata
     )
 
-    . "C:\git\juanpablo.jofre@bitbucket.org\powershell\PowerShell-Docs\DocumentManagement\Update-Metadata.ps1"
 
     if(-not $newMetadata){
         $newMetadata = @{


### PR DESCRIPTION
I found two instances where I couldn't run scripts because they included other scripts in a different directory. Changed them both to be local. Let me know if this breaks anything - 
